### PR TITLE
Add cafes dataset near adventure spots

### DIFF
--- a/content/food/cafes.csv
+++ b/content/food/cafes.csv
@@ -1,0 +1,60 @@
+slug,name,region,lat,lon,near_spots,specialty,dog_friendly,outdoor_seating,description
+coed-y-brenin-visitor-centre-cafe,Coed y Brenin Visitor Centre Cafe,snowdonia,52.8220,-3.8690,Coed y Brenin,Cafe menu,Yes,Yes,Cafe located at the Coed y Brenin Visitor Centre, popular with mountain bikers and walkers.
+bikepark-wales-cafe,BikePark Wales Cafe,brecon-beacons,51.7250,-3.3700,BikePark Wales,Cafe menu,Check restrictions,Yes,On-site cafe at BikePark Wales serving riders.
+antur-stiniog-cafe,Antur Stiniog Cafe,snowdonia,52.9940,-3.9380,Antur Stiniog,Cafe menu,Yes,Yes,Cafe at the Antur Stiniog downhill centre.
+oneplanet-adventure-cafe,Oneplanet Adventure Cafe,north-wales,53.0560,-3.1910,Llandegla Forest,Cafe menu,Yes,Yes,Cafe at Llandegla Forest, serving mountain bikers.
+elan-valley-visitor-centre-cafe,Elan Valley Visitor Centre Cafe,mid-wales,52.2700,-3.5500,Elan Valley,Cafe menu,Yes,Yes,Visitor centre cafe in the Elan Valley.
+canolfan-tryweryn-cafe,Canolfan Tryweryn Cafe,snowdonia,52.9110,-3.6010,Bala White Water Centre,Cafe menu,Yes,Yes,Cafe at the National White Water Centre.
+penceunant-isaf-tea-rooms,Penceunant Isaf Tea Rooms,snowdonia,53.1190,-4.1310,Snowdon,Cafe menu,Yes,Yes,Traditional tea room on the Llanberis Path.
+petes-eats,Pete's Eats,snowdonia,53.1190,-4.1310,Llanberis,Cafe menu,Yes,No,Famous walkers' cafe in Llanberis.
+caffi-gwynant,Caffi Gwynant,snowdonia,53.0800,-4.0200,Snowdon,Cafe menu,Yes,Yes,Cafe at the base of the Watkin Path.
+moel-siabod-cafe,Moel Siabod Cafe,snowdonia,53.0960,-3.9100,Capel Curig,Cafe menu,Yes,Yes,Popular cafe for climbers and hikers in Capel Curig.
+plas-y-brenin-cafe,Plas y Brenin Cafe,snowdonia,53.0960,-3.9100,Plas y Brenin,Cafe menu,Yes,Yes,Cafe and bar at the National Outdoor Centre.
+pen-y-fan-food-truck,Pen y Fan Food Truck,brecon-beacons,51.8830,-3.4370,Pen y Fan,Cafe menu,Yes,Yes,Popular food truck at the Pont ar Daf car park.
+the-old-barn-tea-room,The Old Barn Tea Room,brecon-beacons,51.8830,-3.4370,Brecon Beacons,Cafe menu,Yes,Yes,Tea room popular with walkers in the Brecon Beacons.
+cafe-mor,Cafe Môr,pembrokeshire,51.6580,-5.0480,Freshwater West,Seafood,Yes,Yes,Famous food truck at Freshwater West beach.
+the-boathouse,The Boathouse,pembrokeshire,51.6160,-4.8910,Stackpole Quay,Cafe menu,Yes,Yes,Cafe at Stackpole Quay, near Barafundle Bay.
+mamgu-welshcakes,Mamgu Welshcakes,pembrokeshire,51.8810,-5.2660,St Davids,Welsh cakes,Yes,Yes,Welsh cake specialist in St Davids.
+the-pebbles,The Pebbles,pembrokeshire,51.8810,-5.2660,St Davids,Cafe menu,Yes,Yes,Cafe in St Davids.
+oriel-y-parc-cafe,Oriel y Parc Cafe,pembrokeshire,51.8810,-5.2660,St Davids,Cafe menu,Yes,Yes,Cafe at the National Park Visitor Centre in St Davids.
+whitesands-beach-house,Whitesands Beach House,pembrokeshire,51.8920,-5.3030,Whitesands Beach,Cafe menu,Check restrictions,Yes,Beachside cafe at Whitesands Bay.
+sands-cafe-newgale,Sands Cafe,pembrokeshire,51.8580,-5.1200,Newgale Beach,Cafe menu,Check restrictions,Yes,Cafe at Newgale Beach.
+surfside-cafe-caswell,Surfside Cafe,gower,51.5750,-4.0330,Caswell Bay,Cafe menu,Check restrictions,Yes,Beachside cafe at Caswell Bay.
+surfside-cafe-langland,Surfside Cafe,gower,51.5670,-4.0080,Langland Bay,Cafe menu,Check restrictions,Yes,Beachside cafe at Langland Bay.
+the-lookout,The Lookout,gower,51.5690,-4.2870,Rhossili Bay,Cafe menu,Yes,Yes,Cafe with views over Rhossili Bay.
+bay-bistro,Bay Bistro,gower,51.5690,-4.2870,Rhossili Bay,Cafe menu,Yes,Yes,Bistro and cafe at Rhossili.
+eddys,Eddy's,gower,51.5970,-4.2680,Llangennith,Cafe menu,Yes,Yes,Cafe and bar at Hillend Camping, Llangennith.
+pjs-surf-shop-cafe,PJ's Surf Shop Cafe,gower,51.5970,-4.2680,Llangennith,Cafe menu,Yes,Yes,Surf shop with cafe facilities in Llangennith.
+three-cliffs-coffee-shop,Three Cliffs Coffee Shop,gower,51.5760,-4.1160,Three Cliffs Bay,Cafe menu,Yes,Yes,Coffee shop near Three Cliffs Bay.
+oxwich-bay-cafe,Oxwich Bay Cafe,gower,51.5580,-4.1650,Oxwich Bay,Cafe menu,Check restrictions,Yes,Cafe at Oxwich Bay.
+captains-table,Captain's Table,gower,51.5460,-4.2150,Port Eynon,Cafe menu,Yes,Yes,Fish and chips and cafe at Port Eynon.
+ty-coch-inn,Ty Coch Inn,llyn-peninsula,52.9450,-4.5300,Morfa Nefyn,Cafe menu,Yes,Yes,Iconic beachfront inn at Porthdinllaen.
+caffi-porthor,Caffi Porthor,llyn-peninsula,52.8350,-4.7200,Whistling Sands,Cafe menu,Check restrictions,Yes,Seasonal cafe at Whistling Sands beach.
+becws-islyn,Becws Islyn,llyn-peninsula,52.8050,-4.7100,Aberdaron,Cafe menu,Yes,Yes,Bakery and cafe in Aberdaron.
+gwesty-ty-newydd,Gwesty Ty Newydd,llyn-peninsula,52.8050,-4.7100,Aberdaron,Cafe menu,Yes,Yes,Hotel with cafe/restaurant terrace overlooking the beach.
+mojos,Mojo's,anglesey,53.2310,-4.5200,Rhosneigr,Cafe menu,Yes,Yes,Popular creperie and cafe in Rhosneigr.
+surf-cafe-rhosneigr,Surf Cafe Rhosneigr,anglesey,53.2310,-4.5200,Rhosneigr,Cafe menu,Yes,Yes,Cafe catering to watersports enthusiasts in Rhosneigr.
+sea-shanty-cafe,Sea Shanty Cafe,anglesey,53.2810,-4.6300,Trearddur Bay,Cafe menu,Yes,Yes,Nautical themed cafe and restaurant in Trearddur Bay.
+rspb-south-stack-cafe,RSPB South Stack Cafe,anglesey,53.3060,-4.7000,South Stack,Cafe menu,Yes,Yes,Cafe at the RSPB South Stack reserve with sea views.
+plas-menai-cafe,Plas Menai Cafe,north-wales,53.1330,-4.2700,Plas Menai,Cafe menu,Yes,Yes,Cafe at the National Watersports Centre.
+dylans-menai-bridge,Dylan's Menai Bridge,anglesey,53.2260,-4.1630,Menai Bridge,Cafe menu,Yes,Yes,Restaurant and cafe at Menai Bridge waterfront.
+caffi-cemaes,Caffi Cemaes,anglesey,53.4120,-4.4500,Cemaes Bay,Cafe menu,Yes,Yes,Cafe in Cemaes Bay.
+wavecrest-cafe,Wavecrest Cafe,anglesey,53.3810,-4.5200,Church Bay,Cafe menu,Yes,Yes,Cafe at Church Bay.
+abersoch-beach-cafe,Abersoch Beach Cafe,llyn-peninsula,52.8240,-4.5000,Abersoch,Cafe menu,Check restrictions,Yes,Beachside cafe in Abersoch.
+zinc-cafe,Zinc Cafe,llyn-peninsula,52.8240,-4.5000,Abersoch,Cafe menu,Yes,Yes,Cafe and bar in Abersoch with harbour views.
+caffi-meinir,Caffi Meinir,llyn-peninsula,52.9350,-4.5230,Nant Gwrtheyrn,Cafe menu,Yes,Yes,Cafe at the Nant Gwrtheyrn language centre.
+alpine-coffee-shop,Alpine Coffee Shop,snowdonia,53.0920,-3.8000,Betws-y-Coed,Cafe menu,Yes,Yes,Popular coffee shop in Betws-y-Coed station.
+hangin-pizzeria,Hangin' Pizzeria,snowdonia,53.0920,-3.8000,Betws-y-Coed,Cafe menu,Yes,Yes,Pizzeria and cafe in Betws-y-Coed.
+conwy-falls-cafe,Conwy Falls Cafe,snowdonia,53.0920,-3.8000,Betws-y-Coed,Cafe menu,Yes,Yes,Cafe designed by Clough Williams-Ellis near Conwy Falls.
+llangorse-lake-cafe,Llangorse Lake Cafe,brecon-beacons,51.9230,-3.2600,Llangorse Lake,Cafe menu,Yes,Yes,Cafe overlooking Llangorse Lake.
+black-mountain-activity-centre-cafe,Black Mountain Activity Centre Cafe,brecon-beacons,52.0400,-3.1800,Three Cocks,Cafe menu,Yes,Yes,Cafe at the Black Mountain Activity Centre.
+borth-beach-cafe,Borth Beach Cafe,mid-wales,52.4900,-4.0500,Borth Beach,Cafe menu,Check restrictions,Yes,Cafe at Borth Beach.
+ynyslas-visitor-centre-cafe,Ynyslas Visitor Centre Cafe,mid-wales,52.5200,-4.0500,Ynyslas Beach,Cafe menu,Check restrictions,Yes,Seasonal cafe at the Ynyslas Visitor Centre.
+machynlleth-cafe,Machynlleth Cafe,mid-wales,52.5900,-3.8500,Machynlleth,Cafe menu,Yes,Yes,"Cafe in Machynlleth, near Dyfi Forest trails."
+devils-bridge-cafe,Devil's Bridge Cafe,mid-wales,52.3770,-3.8500,Devil's Bridge,Cafe menu,Yes,Yes,Cafe at the Devil's Bridge Waterfalls.
+caffi-clywedog,Caffi Clywedog,mid-wales,52.4700,-3.5800,Llyn Clywedog,Cafe menu,Yes,Yes,Cafe overlooking Llyn Clywedog.
+blue-china,Blue China,llyn-peninsula,52.9180,-4.2330,Criccieth,Cafe menu,Yes,Yes,Tea room in Criccieth.
+dylans-criccieth,Dylan's Criccieth,llyn-peninsula,52.9180,-4.2330,Criccieth,Cafe menu,Yes,Yes,Restaurant and cafe in the Art Deco building at Criccieth.
+rest-bay-cafe,Rest Bay Cafe,south-wales,51.4934,-3.7234,Rest Bay,Cafe menu,Yes,Yes,Cafe at the Rest Bay Watersports Centre.
+barry-island-cafe,Barry Island Cafe,south-wales,51.3900,-3.2750,Barry Island,Cafe menu,Yes,Yes,Cafe on the Barry Island promenade.
+marcos-cafe,Marco's Cafe,south-wales,51.3900,-3.2750,Barry Island,Cafe menu,Yes,Yes,Famous cafe from Gavin & Stacey on Barry Island.


### PR DESCRIPTION
Added a new dataset `content/food/cafes.csv` containing 60 cafes located near adventure spots in Wales.
Data is grounded in existing location coordinates found in `content/locations.csv`, `content/spots/surfing/breaks.csv`, and `content/spots/coasteering/spots.csv`.
The dataset covers trail centres (Coed y Brenin, BikePark Wales), mountain hubs (Snowdonia, Brecon Beacons), and coastal spots (Pembrokeshire, Gower, Llyn Peninsula, Anglesey).
Fields included: slug, name, region, lat, lon, near_spots, specialty, dog_friendly, outdoor_seating, description.
Default values ("Cafe menu", "Check restrictions") used where specific attributes could not be verified from codebase.

---
*PR created automatically by Jules for task [8165974220408843810](https://jules.google.com/task/8165974220408843810) started by @mk-162*