### PR TITLE
Improve mobile content parity and stacking fixes

### DIFF
--- a/src/app/[region]/page.tsx
+++ b/src/app/[region]/page.tsx
@@ -565,7 +565,7 @@ export default async function RegionPage({ params }: RegionPageProps) {
               src={`/images/regions/${regionSlug}-hero.jpg`}
             />
             {/* Gradient overlay for text readability */}
-            <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/30 to-transparent" />
+            <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/30 to-transparent" />
           </div>
 
           <div className="absolute top-4 right-4 flex gap-2 lg:hidden z-20">
@@ -609,7 +609,10 @@ export default async function RegionPage({ params }: RegionPageProps) {
         </div>
 
         {/* Sticky Section Nav */}
-        <nav className="sticky top-[64px] z-40 bg-white/80 backdrop-blur-md pt-2 pb-3 lg:pb-4 mb-4 lg:mb-6 -mx-4 px-4 sm:mx-0 sm:px-0">
+        <nav
+          className="sticky z-40 bg-white/80 backdrop-blur-md pt-2 pb-3 lg:pb-4 mb-4 lg:mb-6 -mx-4 px-4 sm:mx-0 sm:px-0"
+          style={{ top: "var(--header-height)" }}
+        >
           <div className="flex overflow-x-auto border-b border-gray-200 gap-4 lg:gap-8 no-scrollbar">
             {activities.length > 0 && (
               <AnchorTab href="#activities" label="Activities" />

--- a/src/app/answers/[slug]/page.tsx
+++ b/src/app/answers/[slug]/page.tsx
@@ -523,6 +523,42 @@ export default async function AnswerPage({ params }: Props) {
               </div>
             </div>
 
+            {/* Mobile Sidebar Content */}
+            <div className="lg:hidden space-y-6 mb-10">
+              <div className="bg-primary rounded-xl p-6 text-white relative overflow-hidden">
+                <div className="absolute -right-10 -top-10 w-32 h-32 bg-white/10 rounded-full blur-2xl" />
+                <h3 className="text-xl font-bold mb-2 relative z-10">Book an Adventure</h3>
+                <p className="text-white/80 text-sm mb-4 relative z-10">
+                  Ready to explore? Find guided adventures in {frontmatter.region ? formatRegionName(frontmatter.region) : "Wales"}.
+                </p>
+                <Link
+                  href={frontmatter.region ? `/${frontmatter.region}/things-to-do` : "/activities"}
+                  className="block w-full py-3 bg-white text-primary font-bold rounded-lg text-sm text-center hover:bg-gray-100 transition-colors relative z-10"
+                >
+                  Find Activities
+                </Link>
+              </div>
+
+              {frontmatter.region && (
+                <div className="rounded-xl overflow-hidden h-40 relative shadow-sm border border-gray-200">
+                  <img 
+                    alt={`Map of ${formatRegionName(frontmatter.region)}`}
+                    className="w-full h-full object-cover"
+                    src={`/images/regions/${frontmatter.region}-hero.jpg`}
+                  />
+                  <div className="absolute inset-0 flex items-center justify-center bg-black/10 hover:bg-black/20 transition-colors cursor-pointer">
+                    <Link
+                      href={`/${frontmatter.region}`}
+                      className="bg-white/90 backdrop-blur text-primary px-4 py-2 rounded-lg font-bold text-sm shadow-sm flex items-center gap-2"
+                    >
+                      <MapPin className="w-4 h-4" />
+                      Explore {formatRegionName(frontmatter.region)}
+                    </Link>
+                  </div>
+                </div>
+              )}
+            </div>
+
             {/* Related Answers (visible on all screens, useful for mobile) */}
             {relatedAnswers.length > 0 && (
               <section className="mt-10 pt-8 border-t border-gray-200">
@@ -616,7 +652,7 @@ export default async function AnswerPage({ params }: Props) {
                 <div className="rounded-xl overflow-hidden h-40 relative shadow-sm border border-gray-200">
                   <img 
                     alt={`Map of ${formatRegionName(frontmatter.region)}`}
-                    className="w-full h-full object-cover opacity-80"
+                    className="w-full h-full object-cover"
                     src={`/images/regions/${frontmatter.region}-hero.jpg`}
                   />
                   <div className="absolute inset-0 flex items-center justify-center bg-black/10 hover:bg-black/20 transition-colors cursor-pointer">

--- a/src/app/destinations/page.tsx
+++ b/src/app/destinations/page.tsx
@@ -54,7 +54,7 @@ export default async function DestinationsPage() {
               className="absolute inset-0 bg-cover bg-center transition-transform duration-700 group-hover:scale-105"
               style={{ backgroundImage: `url('/images/regions/${regions[0].slug}-hero.jpg')` }}
             />
-            <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent" />
+            <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/20 to-transparent" />
             <div className="absolute bottom-0 left-0 p-6 lg:p-10">
               <span className="bg-accent-hover text-white text-xs font-bold px-3 py-1 rounded-full mb-3 inline-block">
                 Featured
@@ -107,7 +107,7 @@ export default async function DestinationsPage() {
                 className="absolute inset-0 bg-cover bg-center transition-transform duration-500 group-hover:scale-110"
                 style={{ backgroundImage: `url('/images/regions/${region.slug}-hero.jpg')` }}
               />
-              <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent" />
+              <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/20 to-transparent" />
               <div className="absolute bottom-0 left-0 p-5">
                 <h3 className="text-xl font-bold text-white mb-1">{region.name}</h3>
                 <p className="text-white/70 text-sm flex items-center gap-1">

--- a/src/app/directory/[slug]/page.tsx
+++ b/src/app/directory/[slug]/page.tsx
@@ -112,7 +112,7 @@ export default async function OperatorProfilePage({ params }: Props) {
     : null;
 
   return (
-    <div className="min-h-screen pb-24 lg:pb-12">
+    <div className="min-h-screen pb-24 lg:pb-12 has-bottom-bar">
       {/* Structured Data */}
       <JsonLd data={createLocalBusinessSchema(operator)} />
       <JsonLd data={createBreadcrumbSchema([
@@ -501,6 +501,205 @@ export default async function OperatorProfilePage({ params }: Props) {
                 )}
               </div>
             </section>
+          </div>
+
+          {/* Mobile Sidebar Content */}
+          <div className="lg:hidden space-y-6">
+            {operator.claimStatus !== "claimed" && !isPremium && (
+              <ClaimListingBanner
+                operatorSlug={operator.slug}
+                operatorName={operator.name}
+                variant="inline"
+              />
+            )}
+
+            <div className="bg-gradient-to-br from-accent-hover/5 to-amber-50 rounded-xl border border-accent-hover/20 p-6 shadow-lg shadow-accent-hover/10">
+              <h3 className="text-lg font-bold text-primary mb-2">
+                {operator.bookingPlatform && operator.bookingPlatform !== "none"
+                  ? (operator.bookingPlatform === "direct" ? "Book Direct" : "Book Online")
+                  : "Get In Touch"}
+              </h3>
+              <p className="text-sm text-gray-600 mb-4">
+                {operator.bookingPlatform === "beyonk" 
+                  ? "Instant availability — book securely via Beyonk"
+                  : operator.bookingPlatform === "rezdy"
+                  ? "Check availability and book online via Rezdy"
+                  : operator.bookingPlatform === "fareharbor"
+                  ? "Check availability and book online via FareHarbor"
+                  : operator.bookingPlatform === "direct"
+                  ? "Book directly with the provider"
+                  : "Contact them to check availability and book"}
+              </p>
+
+              <div className="flex flex-col gap-3">
+                <a
+                  href={operator.bookingWidgetUrl || operator.website || "#"}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="w-full flex items-center justify-center gap-2 bg-accent-hover hover:bg-accent-hover text-white font-bold py-3 px-4 rounded-xl transition-colors shadow-md shadow-accent-hover/30"
+                >
+                  {operator.bookingPlatform === "beyonk" ? "Book via Beyonk" 
+                    : operator.bookingPlatform === "rezdy" ? "Book via Rezdy"
+                    : operator.bookingPlatform === "fareharbor" ? "Book via FareHarbor"
+                    : operator.bookingPlatform === "direct" ? "Book Direct"
+                    : "Visit Website"}
+                  <ExternalLink className="w-4 h-4" />
+                </a>
+
+                {operator.phone && (
+                  <a
+                    href={`tel:${operator.phone}`}
+                    className="w-full flex items-center justify-center gap-2 bg-primary hover:bg-primary/90 text-white font-bold py-3 px-4 rounded-xl transition-colors"
+                  >
+                    <Phone className="w-4 h-4" />
+                    Call {operator.phone}
+                  </a>
+                )}
+
+                {operator.bookingPlatform && operator.bookingPlatform !== "none" && operator.bookingPlatform !== "direct" && operator.website && (
+                  <a
+                    href={operator.website}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="w-full flex items-center justify-center gap-2 text-primary hover:text-accent-hover font-medium py-2 text-sm transition-colors"
+                  >
+                    <Globe className="w-4 h-4" />
+                    Visit Website
+                  </a>
+                )}
+              </div>
+
+              {operator.bookingPlatform && operator.bookingPlatform !== "none" && operator.bookingPlatform !== "direct" && (
+                <p className="text-xs text-center text-gray-400 mt-3 flex items-center justify-center gap-1">
+                  Powered by {operator.bookingPlatform.charAt(0).toUpperCase() + operator.bookingPlatform.slice(1)}
+                </p>
+              )}
+            </div>
+
+            <div className="bg-white rounded-xl p-5 border border-gray-200 shadow-lg shadow-gray-200/50">
+              <h4 className="text-sm font-bold text-primary mb-3">Contact Details</h4>
+              <ul className="space-y-3">
+                {operator.phone && (
+                  <li className="flex items-center gap-3">
+                    <Phone className="w-4 h-4 text-primary" />
+                    <a href={`tel:${operator.phone}`} className="text-sm text-gray-600 hover:text-primary">
+                      {operator.phone}
+                    </a>
+                  </li>
+                )}
+                {operator.email && (
+                  <li className="flex items-center gap-3">
+                    <Mail className="w-4 h-4 text-primary" />
+                    <a href={`mailto:${operator.email}?subject=${encodeURIComponent("Enquiry from Adventure Wales")}`} className="text-sm text-gray-600 hover:text-primary">
+                      {operator.email}
+                    </a>
+                  </li>
+                )}
+              </ul>
+
+              <div className="mt-4 space-y-2">
+                {operator.website && (
+                  <a 
+                    href={operator.website} 
+                    target="_blank" 
+                    rel="noopener noreferrer"
+                    className="flex items-center justify-center gap-2 w-full py-2.5 bg-primary hover:bg-primary/90 text-white font-semibold rounded-xl text-sm transition-colors"
+                  >
+                    <Globe className="w-4 h-4" />
+                    Visit Website
+                    <ExternalLink className="w-3 h-3" />
+                  </a>
+                )}
+                {operator.email && (
+                  <a 
+                    href={`mailto:${operator.email}?subject=${encodeURIComponent("Enquiry from Adventure Wales")}`}
+                    className="flex items-center justify-center gap-2 w-full py-2.5 border-2 border-primary text-primary font-semibold rounded-xl text-sm hover:bg-primary/5 transition-colors"
+                  >
+                    <Mail className="w-4 h-4" />
+                    Email Directly
+                  </a>
+                )}
+              </div>
+            </div>
+
+            <div className="bg-gray-50 rounded-xl border border-gray-200 p-6">
+              <h3 className="text-base font-bold text-primary mb-4">Send a Quick Enquiry</h3>
+              <form className="flex flex-col gap-4">
+                <div>
+                  <label className="block text-xs font-semibold text-gray-700 mb-1">Your Name</label>
+                  <input 
+                    type="text"
+                    className="w-full rounded-lg bg-gray-50 border-gray-200 text-sm focus:ring-primary focus:border-primary px-4 py-2.5"
+                    placeholder="Enter your name"
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs font-semibold text-gray-700 mb-1">Email</label>
+                  <input 
+                    type="email"
+                    className="w-full rounded-lg bg-gray-50 border-gray-200 text-sm focus:ring-primary focus:border-primary px-4 py-2.5"
+                    placeholder="your@email.com"
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs font-semibold text-gray-700 mb-1">Message</label>
+                  <textarea 
+                    className="w-full rounded-lg bg-gray-50 border-gray-200 text-sm focus:ring-primary focus:border-primary resize-none px-4 py-2.5"
+                    rows={3}
+                    placeholder="I'm interested in..."
+                  />
+                </div>
+                <button 
+                  type="button"
+                  className="w-full bg-accent-hover hover:bg-accent-hover/90 text-white font-bold py-3 px-4 rounded-xl transition-colors mt-2"
+                >
+                  Send Enquiry
+                </button>
+                {operator.email && (
+                  <p className="text-xs text-center text-gray-500 mt-3">
+                    Or email us directly:{" "}
+                    <a 
+                      href={`mailto:${operator.email}?subject=${encodeURIComponent("Enquiry from Adventure Wales")}`}
+                      className="text-primary hover:text-accent-hover underline font-medium"
+                    >
+                      {operator.email}
+                    </a>
+                  </p>
+                )}
+                {!operator.email && (
+                  <p className="text-xs text-center text-gray-400">
+                    Or call {operator.phone || "directly"}
+                  </p>
+                )}
+              </form>
+            </div>
+
+            {(operator.lat && operator.lng) && (
+              <div className="rounded-xl overflow-hidden shadow-sm border border-gray-200">
+                <MapView
+                  markers={[{
+                    id: `operator-${operator.id}`,
+                    lat: parseFloat(String(operator.lat)),
+                    lng: parseFloat(String(operator.lng)),
+                    type: "operator" as const,
+                    title: operator.name,
+                    subtitle: operator.address?.split(",")[0] || undefined,
+                    link: `/directory/${operator.slug}`,
+                  }]}
+                  height="200px"
+                  zoom={13}
+                  interactive={false}
+                />
+                <a
+                  href={`https://www.google.com/maps/dir/?api=1&destination=${operator.lat},${operator.lng}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="block text-center py-2 text-xs font-medium text-accent-hover hover:bg-gray-50 transition-colors border-t border-gray-200"
+                >
+                  Get Directions →
+                </a>
+              </div>
+            )}
           </div>
 
           {/* Sidebar Column (desktop only) */}

--- a/src/app/events/[slug]/page.tsx
+++ b/src/app/events/[slug]/page.tsx
@@ -87,11 +87,12 @@ export default async function EventPage({ params }: Props) {
         {/* Hero */}
         <section className="relative h-[40vh] min-h-[300px] bg-primary">
           <div
-            className="absolute inset-0 bg-cover bg-center opacity-40"
+            className="absolute inset-0 bg-cover bg-center"
             style={{
               backgroundImage: `url('${heroImage}')`,
             }}
           />
+          <div className="absolute inset-0 bg-gradient-to-b from-black/50 via-black/30 to-black/60" />
           <div className="relative h-full max-w-7xl mx-auto px-4 flex flex-col justify-end pb-8">
             {/* Breadcrumb */}
             <nav className="flex items-center gap-2 text-sm text-gray-300 mb-4">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -17,6 +17,8 @@
   --muted: #f8fafc;
   --muted-foreground: #64748b;
   --border: #e2e8f0;
+  --header-height: 64px;
+  --bottom-bar-height: 88px;
 }
 
 html, body {
@@ -46,6 +48,29 @@ body {
 /* Smooth scrolling */
 html {
   scroll-behavior: smooth;
+  scroll-padding-top: var(--header-height);
+}
+
+/* Leaflet stacking fixes */
+.leaflet-container,
+.leaflet-pane {
+  z-index: 0;
+}
+
+.leaflet-control-container,
+.leaflet-top,
+.leaflet-bottom,
+.leaflet-control {
+  z-index: 10;
+}
+
+.leaflet-popup {
+  z-index: 20;
+}
+
+/* Utility for fixed bottom bars */
+.has-bottom-bar {
+  padding-bottom: calc(var(--bottom-bar-height) + env(safe-area-inset-bottom));
 }
 
 /* Custom scrollbar */

--- a/src/app/itineraries/[slug]/page.tsx
+++ b/src/app/itineraries/[slug]/page.tsx
@@ -67,7 +67,7 @@ export default async function ItineraryDetailPage({ params }: Props) {
   );
 
   return (
-    <div className="min-h-screen pt-4 lg:pt-6 pb-24 lg:pb-12 bg-gray-50/50">
+    <div className="min-h-screen pt-4 lg:pt-6 pb-24 lg:pb-12 bg-gray-50/50 has-bottom-bar">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         {/* Breadcrumbs */}
         <div className="flex items-center gap-2 text-sm text-gray-500 mb-4 lg:mb-6">

--- a/src/app/surfing/page.tsx
+++ b/src/app/surfing/page.tsx
@@ -109,7 +109,7 @@ export default async function SurfingHubPage() {
           className="absolute inset-0 bg-cover bg-center"
           style={{ backgroundImage: "url('/images/activities/surfing-hero.jpg')" }}
         />
-        <div className="absolute inset-0 bg-gradient-to-b from-primary/80 via-primary/60 to-primary/90" />
+        <div className="absolute inset-0 bg-gradient-to-b from-primary/70 via-primary/50 to-primary/80" />
 
         {/* Hero Content */}
         <div className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">

--- a/src/components/itinerary/ItineraryView.tsx
+++ b/src/components/itinerary/ItineraryView.tsx
@@ -180,6 +180,115 @@ export function ItineraryView({ stops, accommodations = [], itineraryName, itine
 
       </div>
 
+      {/* Mobile Sidebar Content */}
+      <div className="lg:hidden space-y-6">
+        {(durationDays || difficulty || bestSeason || region || stops.length > 0) && (
+          <div className="bg-white rounded-2xl shadow-lg border border-gray-200 overflow-hidden">
+            <div className="bg-gradient-to-r from-primary to-[#2d5a73] px-5 py-3">
+              <h3 className="text-white font-bold text-sm flex items-center gap-2">
+                <Map className="w-4 h-4" />
+                Trip Overview
+              </h3>
+            </div>
+            <div className="p-5 space-y-3">
+              {durationDays && (
+                <div className="flex items-center gap-3">
+                  <div className="w-8 h-8 rounded-lg bg-blue-50 flex items-center justify-center">
+                    <Clock className="w-4 h-4 text-blue-600" />
+                  </div>
+                  <div>
+                    <div className="text-[10px] font-bold text-gray-400 uppercase tracking-wider">Duration</div>
+                    <div className="text-sm font-bold text-primary">{durationDays} day{durationDays !== 1 ? "s" : ""}</div>
+                  </div>
+                </div>
+              )}
+              {difficulty && (
+                <div className="flex items-center gap-3">
+                  <div className="w-8 h-8 rounded-lg bg-orange-50 flex items-center justify-center">
+                    <Mountain className="w-4 h-4 text-orange-600" />
+                  </div>
+                  <div>
+                    <div className="text-[10px] font-bold text-gray-400 uppercase tracking-wider">Difficulty</div>
+                    <div className="text-sm font-bold text-primary capitalize">{difficulty}</div>
+                  </div>
+                </div>
+              )}
+              {bestSeason && (
+                <div className="flex items-center gap-3">
+                  <div className="w-8 h-8 rounded-lg bg-green-50 flex items-center justify-center">
+                    <Sun className="w-4 h-4 text-green-600" />
+                  </div>
+                  <div>
+                    <div className="text-[10px] font-bold text-gray-400 uppercase tracking-wider">Best Season</div>
+                    <div className="text-sm font-bold text-primary">{bestSeason}</div>
+                  </div>
+                </div>
+              )}
+              {(priceEstimateFrom || priceEstimateTo) && (
+                <div className="flex items-center gap-3">
+                  <div className="w-8 h-8 rounded-lg bg-amber-50 flex items-center justify-center">
+                    <PoundSterling className="w-4 h-4 text-amber-600" />
+                  </div>
+                  <div>
+                    <div className="text-[10px] font-bold text-gray-400 uppercase tracking-wider">Budget Estimate</div>
+                    <div className="text-sm font-bold text-primary">
+                      {priceEstimateFrom && priceEstimateTo
+                        ? `£${priceEstimateFrom}–£${priceEstimateTo}`
+                        : `From £${priceEstimateFrom || priceEstimateTo}`}
+                    </div>
+                  </div>
+                </div>
+              )}
+              {region && (
+                <div className="flex items-center gap-3">
+                  <div className="w-8 h-8 rounded-lg bg-purple-50 flex items-center justify-center">
+                    <MapPin className="w-4 h-4 text-purple-600" />
+                  </div>
+                  <div>
+                    <div className="text-[10px] font-bold text-gray-400 uppercase tracking-wider">Region</div>
+                    <div className="text-sm font-bold text-primary">{region.name}</div>
+                  </div>
+                </div>
+              )}
+              {stops.length > 0 && (
+                <div className="flex items-center gap-3">
+                  <div className="w-8 h-8 rounded-lg bg-teal-50 flex items-center justify-center">
+                    <Star className="w-4 h-4 text-teal-600" />
+                  </div>
+                  <div>
+                    <div className="text-[10px] font-bold text-gray-400 uppercase tracking-wider">Stops</div>
+                    <div className="text-sm font-bold text-primary">
+                      {stops.length} stop{stops.length !== 1 ? "s" : ""} across {days.length} day{days.length !== 1 ? "s" : ""}
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+
+        {region?.lat && region?.lng && (
+          <WeatherWidget 
+            lat={parseFloat(String(region.lat))} 
+            lng={parseFloat(String(region.lng))} 
+            regionName={region.name} 
+            compact
+          />
+        )}
+        {region?.slug && (
+          <ClimateChart regionSlug={region.slug} compact />
+        )}
+        <div id="itinerary-costs">
+          <CostBreakdown stops={stops} mode={mode} itineraryName={itineraryName} itineraryId={itineraryId} />
+        </div>
+        {itinerarySlug && (
+          <ThingsToBook stops={stops} itinerarySlug={itinerarySlug} mode={mode} />
+        )}
+        {itineraryName && (
+          <TripNotes itinerarySlug={itineraryName.toLowerCase().replace(/[^a-z0-9]+/g, "-")} />
+        )}
+      </div>
+
       {/* Right Column: Sidebar */}
       <aside className="hidden lg:block lg:col-span-4 space-y-6">
          {/* Quick Fact Sheet */}


### PR DESCRIPTION
### Motivation
- Prevent map controls and popups from overlapping sticky UI and ensure consistent scroll offset for sticky navigation by introducing shared layout tokens and z-index fixes.  
- Soften hero overlays for better banner legibility across multiple pages.  
- Surface sidebar widgets and CTAs in mobile layouts and add bottom-bar padding so important actions are available to mobile users.

### Description
- Added layout tokens and utilities in `src/app/globals.css`: `--header-height`, `--bottom-bar-height`, `scroll-padding-top`, Leaflet z-index stacking rules, and the `.has-bottom-bar` helper.  
- Aligned the region page sticky nav offset to the header token by updating `src/app/[region]/page.tsx` to use `style={{ top: "var(--header-height)" }}`.  
- Softened gradient overlays for hero/cover images in `src/app/events/[slug]/page.tsx`, `src/app/destinations/page.tsx`, and `src/app/surfing/page.tsx`.  
- Restored mobile sidebar content and CTAs by adding mobile-only widgets to `src/app/answers/[slug]/page.tsx`, `src/components/itinerary/ItineraryView.tsx`, and `src/app/directory/[slug]/page.tsx`, and applied the `.has-bottom-bar` class to directory/itinerary pages to ensure spacing for fixed bottom bars.

### Testing
- Attempted to run the dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000`, which started but page rendering failed with an error: `DATABASE_URL environment variable is required`.  
- Attempted automated UI capture using Playwright, but the browser run crashed / timed out in this environment and screenshots could not be produced.  
- Next.js reported a Google Fonts download warning and fell back to the local font; no further runtime checks completed due to the missing `DATABASE_URL`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985dae7d34c8331bbfbf8b04e483983)