### PR TITLE
Directory: add monetisation CTAs, category cards, SEO links and distance-aware sorting

### DIFF
--- a/src/app/directory/page.tsx
+++ b/src/app/directory/page.tsx
@@ -1,7 +1,9 @@
-import { getOperators, getAllRegions, getAllActivityTypes } from "@/lib/queries";
+import { getOperators, getAllRegions, getAllActivityTypes, getFeaturedItineraries } from "@/lib/queries";
 import { DirectoryFilters } from "@/components/directory/DirectoryFilters";
 import { ButtonLink } from "@/components/ui/button";
 import { Pagination } from "@/components/ui/Pagination";
+import { FeaturedItineraries } from "@/components/home/featured-itineraries";
+import { ActivitiesRow } from "@/components/home/activities-row";
 
 interface DirectoryPageProps {
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
@@ -19,10 +21,14 @@ export default async function DirectoryPage({ searchParams }: DirectoryPageProps
   const category = typeof params.category === 'string' ? params.category : undefined;
   const rating = typeof params.rating === 'string' ? params.rating : undefined;
   const query = typeof params.q === 'string' ? params.q : undefined;
+  const sort = typeof params.sort === 'string' ? params.sort : 'recommended';
+  const distance = typeof params.distance === 'string' && params.distance ? parseFloat(params.distance) : undefined;
+  const lat = typeof params.lat === 'string' && params.lat ? parseFloat(params.lat) : undefined;
+  const lng = typeof params.lng === 'string' && params.lng ? parseFloat(params.lng) : undefined;
 
   const minRating = rating ? parseFloat(rating.replace('+', '')) : undefined;
 
-  const [{ operators, total }, regions, activityTypes] = await Promise.all([
+  const [{ operators, total }, regions, activityTypes, featuredItineraries] = await Promise.all([
     getOperators({
       limit,
       offset,
@@ -30,10 +36,15 @@ export default async function DirectoryPage({ searchParams }: DirectoryPageProps
       activityTypeSlug: activity,
       category,
       minRating,
-      query
+      query,
+      sortBy: sort as "recommended" | "rating" | "name" | "distance",
+      maxDistanceKm: distance,
+      lat,
+      lng,
     }),
     getAllRegions(),
     getAllActivityTypes(),
+    getFeaturedItineraries(3),
   ]);
 
   const totalPages = Math.ceil(total / limit);
@@ -55,6 +66,24 @@ export default async function DirectoryPage({ searchParams }: DirectoryPageProps
           searchParams={params}
         />
 
+        <section className="mt-12 bg-white border border-gray-200 rounded-2xl p-8 text-center">
+          <p className="text-sm uppercase tracking-wider text-gray-400 mb-2">Grow Your Adventure Business</p>
+          <h3 className="text-2xl font-bold text-primary mb-3">
+            Add your listing or claim your profile
+          </h3>
+          <p className="text-gray-600 mb-6 max-w-2xl mx-auto">
+            Get discovered by travelers searching by location, activity, and service type. Premium partners get priority placement, sponsored badges, and upgraded cards.
+          </p>
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
+            <ButtonLink href="/advertise" variant="accent">
+              Add Your Listing
+            </ButtonLink>
+            <ButtonLink href="/directory/claim" variant="outline">
+              Claim Your Listing
+            </ButtonLink>
+          </div>
+        </section>
+
         <section className="mt-12 bg-gray-50 rounded-2xl p-8 text-center">
           <h3 className="text-xl font-bold text-primary mb-2">
             Run an adventure business in Wales?
@@ -66,12 +95,22 @@ export default async function DirectoryPage({ searchParams }: DirectoryPageProps
             Claim Your Listing
           </ButtonLink>
         </section>
+
+        {featuredItineraries.length > 0 && (
+          <div className="mt-12">
+            <FeaturedItineraries itineraries={featuredItineraries} />
+          </div>
+        )}
+      </div>
+
+      <div className="mt-4">
+        <ActivitiesRow />
       </div>
     </div>
   );
 }
 
 export const metadata = {
-  title: "Adventure Companies & Guides in Wales — Trusted Local Providers | Adventure Wales",
-  description: "30+ vetted Welsh adventure providers with Google reviews and ratings. Find qualified guides for coasteering, hiking, climbing, kayaking, and mountain biking across Wales.",
+  title: "Adventure Directory Wales — Operators by Location & Activity | Adventure Wales",
+  description: "Discover adventure operators in Wales by location, activity, and service type. Compare trusted guides, gear hire, transport, and accommodation with ratings, distance sorting, and sponsored partners.",
 };

--- a/src/components/directory/DirectoryFilters.tsx
+++ b/src/components/directory/DirectoryFilters.tsx
@@ -4,8 +4,10 @@ import { useState, useEffect, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { OperatorCard } from '@/components/cards/operator-card';
 import { AdvertiseWidget } from '@/components/commercial/AdvertiseWidget';
-import { Search, Award, X } from 'lucide-react';
+import { Search, Award, X, LocateFixed, Sparkles } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
+import { ButtonLink } from '@/components/ui/button';
+import Link from 'next/link';
 
 interface Operator {
   id: number;
@@ -51,16 +53,55 @@ const categoryLabels: Record<string, string> = {
   accommodation: "🏠 Accommodation",
 };
 
+const categoryCards = [
+  {
+    key: "activity_provider",
+    title: "Activity Providers",
+    description: "Guides, instructors & adventure companies",
+    image: "/images/activities/activity-wales-27043-1280-assets-wales.jpg",
+  },
+  {
+    key: "gear_rental",
+    title: "Gear & Hire",
+    description: "Bike hire, wetsuits, climbing kit & more",
+    image: "/images/activities/activity-wales-27041-1280-assets-wales.jpg",
+  },
+  {
+    key: "food_drink",
+    title: "Food & Drink",
+    description: "Post-adventure eats and local spots",
+    image: "/images/activities/activity-wales-27045-1280-assets-wales.jpg",
+  },
+  {
+    key: "transport",
+    title: "Transport",
+    description: "Shuttles, transfers & logistics",
+    image: "/images/activities/activity-wales-27047-1280-assets-wales.jpg",
+  },
+  {
+    key: "accommodation",
+    title: "Accommodation",
+    description: "Stay close to the action",
+    image: "/images/activities/activity-wales-27052-1280-assets-wales.jpg",
+  },
+];
+
 function DirectoryFiltersContent({ operators, regions, activityTypes, totalCount }: DirectoryFiltersProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
 
   // Initialize state from URL
   const [searchQuery, setSearchQuery] = useState(searchParams.get('q') || '');
+  const [locationStatus, setLocationStatus] = useState<'idle' | 'locating' | 'error' | 'ready'>('idle');
   const selectedRegion = searchParams.get('region') || '';
   const selectedActivityType = searchParams.get('activity') || '';
   const selectedCategory = searchParams.get('category') || '';
   const selectedRating = searchParams.get('rating') || '';
+  const selectedSort = searchParams.get('sort') || 'recommended';
+  const selectedDistance = searchParams.get('distance') || '';
+  const latParam = searchParams.get('lat');
+  const lngParam = searchParams.get('lng');
+  const hasGeo = Boolean(latParam && lngParam);
 
   // Debounce search update
   useEffect(() => {
@@ -73,18 +114,22 @@ function DirectoryFiltersContent({ operators, regions, activityTypes, totalCount
     return () => clearTimeout(timeoutId);
   }, [searchQuery, searchParams]);
 
-  const updateFilter = (key: string, value: string) => {
+  const updateFilters = (updates: Record<string, string>) => {
     const params = new URLSearchParams(searchParams.toString());
-    if (value) {
-      params.set(key, value);
-    } else {
-      params.delete(key);
-    }
+    Object.entries(updates).forEach(([key, value]) => {
+      if (value) {
+        params.set(key, value);
+      } else {
+        params.delete(key);
+      }
+    });
     // Reset to page 1 on filter change
     params.delete('page');
 
     router.replace(`/directory?${params.toString()}`, { scroll: false });
   };
+
+  const updateFilter = (key: string, value: string) => updateFilters({ [key]: value });
 
   const clearAllFilters = () => {
     router.replace('/directory', { scroll: false });
@@ -97,7 +142,40 @@ function DirectoryFiltersContent({ operators, regions, activityTypes, totalCount
   const featuredOperators = operators.filter(op => op.claimStatus === "premium");
   const regularOperators = operators.filter(op => op.claimStatus !== "premium");
 
-  const hasActiveFilters = selectedRegion || selectedActivityType || selectedCategory || selectedRating || searchQuery;
+  const hasActiveFilters = selectedRegion || selectedActivityType || selectedCategory || selectedRating || searchQuery || selectedDistance || (selectedSort && selectedSort !== 'recommended');
+
+  const requestLocation = () => {
+    if (!navigator.geolocation) {
+      setLocationStatus('error');
+      return;
+    }
+
+    setLocationStatus('locating');
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        const lat = position.coords.latitude.toFixed(6);
+        const lng = position.coords.longitude.toFixed(6);
+        updateFilters({ lat, lng, sort: 'distance' });
+        setLocationStatus('ready');
+      },
+      () => {
+        setLocationStatus('error');
+      }
+    );
+  };
+
+  const clearLocation = () => {
+    updateFilters({
+      lat: '',
+      lng: '',
+      distance: '',
+      sort: selectedSort === 'distance' ? 'recommended' : selectedSort,
+    });
+    setLocationStatus('idle');
+  };
+
+  const seoRegions = regions.slice(0, 6);
+  const seoActivities = activityTypes.slice(0, 6);
 
   return (
     <>
@@ -117,19 +195,69 @@ function DirectoryFiltersContent({ operators, regions, activityTypes, totalCount
             {totalCount}+ Welsh adventure businesses. Adventure providers, gear hire, food, transport — all in one place.
           </p>
 
-          <div className="mt-6 relative max-w-md">
-            <label htmlFor="directory-search" className="sr-only">Search providers</label>
-            <div className="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none">
-              <Search className="h-5 w-5 text-gray-400" />
+          <div className="mt-6 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div className="relative max-w-md w-full">
+              <label htmlFor="directory-search" className="sr-only">Search providers</label>
+              <div className="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none">
+                <Search className="h-5 w-5 text-gray-400" />
+              </div>
+              <input
+                id="directory-search"
+                type="search"
+                placeholder="Search adventure providers..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="w-full pl-12 pr-4 py-3.5 rounded-xl bg-white text-gray-900 placeholder-gray-400 border-2 border-white focus:border-accent-hover focus:ring-2 focus:ring-accent-hover outline-none shadow-lg text-base"
+              />
             </div>
-            <input
-              id="directory-search"
-              type="search"
-              placeholder="Search adventure providers..."
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              className="w-full pl-12 pr-4 py-3.5 rounded-xl bg-white text-gray-900 placeholder-gray-400 border-2 border-white focus:border-accent-hover focus:ring-2 focus:ring-accent-hover outline-none shadow-lg text-base"
-            />
+
+            <div className="flex flex-wrap gap-3">
+              <ButtonLink href="/advertise" variant="accent" size="sm">
+                Add Your Listing
+              </ButtonLink>
+              <ButtonLink href="/directory/claim" variant="outline" size="sm" className="border-white text-white hover:text-accent-hover hover:border-accent-hover">
+                Claim Your Listing
+              </ButtonLink>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-white border-b">
+        <div className="max-w-7xl mx-auto px-4 py-10">
+          <div className="flex items-center justify-between mb-6">
+            <div>
+              <p className="text-sm uppercase tracking-wider text-gray-400">Browse by Category</p>
+              <h2 className="text-2xl font-bold text-primary">Pick the service type you need</h2>
+            </div>
+            <span className="hidden md:inline-flex items-center gap-2 text-xs font-semibold text-primary bg-slate-100 px-3 py-1.5 rounded-full">
+              <Sparkles className="h-4 w-4" /> Premium partners rise to the top
+            </span>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {categoryCards.map((category) => (
+              <button
+                key={category.key}
+                onClick={() => updateFilter('category', category.key)}
+                className="group text-left rounded-2xl overflow-hidden border border-gray-200 hover:border-accent-hover transition-colors"
+              >
+                <div
+                  className="relative h-36 bg-cover bg-center"
+                  style={{ backgroundImage: `url('${category.image}')` }}
+                >
+                  <div className="absolute inset-0 bg-gradient-to-r from-black/60 via-black/20 to-transparent" />
+                  <div className="absolute bottom-4 left-4 text-white">
+                    <h3 className="text-lg font-bold">{category.title}</h3>
+                    <p className="text-sm text-white/80">{category.description}</p>
+                  </div>
+                </div>
+                <div className="px-4 py-3 flex items-center justify-between text-sm font-semibold text-primary">
+                  {categoryLabels[category.key]}
+                  <span className="text-accent-hover">View listings →</span>
+                </div>
+              </button>
+            ))}
           </div>
         </div>
       </section>
@@ -199,6 +327,54 @@ function DirectoryFiltersContent({ operators, regions, activityTypes, totalCount
               <option value="4.5">4.5+ Stars</option>
             </select>
 
+            <label htmlFor="sort-filter" className="sr-only">Sort results</label>
+            <select
+              id="sort-filter"
+              value={selectedSort}
+              onChange={(e) => updateFilter('sort', e.target.value)}
+              className="border border-gray-200 rounded-lg px-3 py-2 text-sm max-w-[180px]"
+              aria-label="Sort results"
+            >
+              <option value="recommended">Sort: Recommended</option>
+              <option value="distance">Sort: Distance</option>
+              <option value="rating">Sort: Rating</option>
+              <option value="name">Sort: Name A-Z</option>
+            </select>
+
+            <label htmlFor="distance-filter" className="sr-only">Distance radius</label>
+            <select
+              id="distance-filter"
+              value={selectedDistance}
+              onChange={(e) => updateFilter('distance', e.target.value)}
+              className="border border-gray-200 rounded-lg px-3 py-2 text-sm max-w-[180px]"
+              aria-label="Filter by distance"
+            >
+              <option value="">Distance: Any</option>
+              <option value="10">Within 10 km</option>
+              <option value="25">Within 25 km</option>
+              <option value="50">Within 50 km</option>
+              <option value="100">Within 100 km</option>
+            </select>
+
+            <button
+              type="button"
+              onClick={requestLocation}
+              className="inline-flex items-center gap-2 text-sm font-semibold text-primary border border-gray-200 rounded-lg px-3 py-2 hover:border-accent-hover hover:text-accent-hover transition-colors"
+            >
+              <LocateFixed className="h-4 w-4" />
+              {locationStatus === 'locating' ? 'Locating...' : 'Use my location'}
+            </button>
+
+            {hasGeo && (
+              <button
+                type="button"
+                onClick={clearLocation}
+                className="text-sm text-gray-500 hover:text-accent-hover"
+              >
+                Clear location
+              </button>
+            )}
+
             {hasActiveFilters && (
               <button
                 onClick={clearAllFilters}
@@ -242,12 +418,50 @@ function DirectoryFiltersContent({ operators, regions, activityTypes, totalCount
                   <button onClick={() => updateFilter('rating', '')} className="ml-1 text-gray-500 hover:text-gray-900"><X className="h-3 w-3" /></button>
                 </Badge>
               )}
+              {selectedDistance && (
+                <Badge variant="default" className="gap-1 pl-2 pr-1 py-1 font-normal bg-gray-100 text-gray-800 hover:bg-gray-200">
+                  Within {selectedDistance} km
+                  <button onClick={() => updateFilter('distance', '')} className="ml-1 text-gray-500 hover:text-gray-900"><X className="h-3 w-3" /></button>
+                </Badge>
+              )}
+              {selectedSort && selectedSort !== 'recommended' && (
+                <Badge variant="default" className="gap-1 pl-2 pr-1 py-1 font-normal bg-gray-100 text-gray-800 hover:bg-gray-200">
+                  Sort: {selectedSort}
+                  <button onClick={() => updateFilter('sort', 'recommended')} className="ml-1 text-gray-500 hover:text-gray-900"><X className="h-3 w-3" /></button>
+                </Badge>
+              )}
+              {hasGeo && (
+                <Badge variant="default" className="gap-1 pl-2 pr-1 py-1 font-normal bg-gray-100 text-gray-800 hover:bg-gray-200">
+                  Near me
+                  <button onClick={clearLocation} className="ml-1 text-gray-500 hover:text-gray-900"><X className="h-3 w-3" /></button>
+                </Badge>
+              )}
             </div>
           )}
         </div>
       </section>
 
       <div className="max-w-7xl mx-auto px-4 py-8">
+        {!hasGeo && (selectedSort === 'distance' || selectedDistance) && (
+          <div className="mb-6 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+            <span>Distance sorting needs your location to calculate results.</span>
+            <button
+              type="button"
+              onClick={requestLocation}
+              className="inline-flex items-center gap-2 font-semibold text-amber-900"
+            >
+              <LocateFixed className="h-4 w-4" />
+              Share location
+            </button>
+          </div>
+        )}
+
+        {locationStatus === 'error' && (
+          <div className="mb-6 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            We couldn’t access your location. You can still filter by region or activity.
+          </div>
+        )}
+
         {/* Featured Operators */}
         {featuredOperators.length > 0 && (
           <section className="mb-12 bg-gradient-to-br from-primary/5 via-accent-hover/5 to-transparent rounded-2xl p-6 border border-primary/10">
@@ -316,6 +530,44 @@ function DirectoryFiltersContent({ operators, regions, activityTypes, totalCount
               </button>
             </div>
           )}
+        </section>
+
+        <section className="mt-12 rounded-2xl border border-slate-200 bg-white p-6">
+          <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
+            <div>
+              <h3 className="text-xl font-bold text-primary">Popular location + activity searches</h3>
+              <p className="text-sm text-gray-500">Built for SEO and easy discovery — browse location, activity, and service type combos.</p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {seoRegions.map((region) => (
+                <Link
+                  key={region.id}
+                  href={`/directory?region=${region.slug}`}
+                  className="text-xs font-semibold text-primary border border-slate-200 rounded-full px-3 py-1 hover:border-accent-hover hover:text-accent-hover"
+                >
+                  {region.name} directory
+                </Link>
+              ))}
+              {seoActivities.map((activity) => (
+                <Link
+                  key={activity.id}
+                  href={`/directory?activity=${activity.slug}`}
+                  className="text-xs font-semibold text-primary border border-slate-200 rounded-full px-3 py-1 hover:border-accent-hover hover:text-accent-hover"
+                >
+                  {activity.name} providers
+                </Link>
+              ))}
+              {availableCategories.map((category) => (
+                <Link
+                  key={category}
+                  href={`/directory?category=${category}`}
+                  className="text-xs font-semibold text-primary border border-slate-200 rounded-full px-3 py-1 hover:border-accent-hover hover:text-accent-hover"
+                >
+                  {categoryLabels[category] || category}
+                </Link>
+              ))}
+            </div>
+          </div>
         </section>
       </div>
     </>


### PR DESCRIPTION
### Motivation
- Improve monetisation and discoverability of the directory by adding clear CTAs to add/claim listings and surface premium partners. 
- Support SEO-focused discovery by exposing popular region+activity/service-type combinations. 
- Enable location-aware search and sorting so users can find nearby providers (distance + radius filtering). 

### Description
- Extend `getOperators` in `src/lib/queries.ts` to accept `sortBy`, `lat`, `lng`, and `maxDistanceKm` and add an SQL distance expression used for radius filtering and `distance` sorting. 
- Enhance `src/components/directory/DirectoryFilters.tsx` with a category card grid, `Add Your Listing` / `Claim Your Listing` CTAs, a sort select (`recommended|distance|rating|name`), distance radius options, geolocation `Use my location` action, active filter badges for distance/sort/location, and SEO-friendly quick links for region/activity/category combos. 
- Update `src/app/directory/page.tsx` to wire sort/distance/lat/lng params into `getOperators`, surface monetisation CTA section, and render `FeaturedItineraries` and `ActivitiesRow` components; also update page `metadata` to emphasise location/activity/service-type SEO phrasing. 
- Small UI tweaks: operator cards already show claim/premium badges and a claim prompt for unclaimed listings (no schema changes to those components). 

### Testing
- Started the dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000`; server started but page rendering failed because the environment requires a database connection. This test failed due to a missing `DATABASE_URL` environment variable. 
- A Playwright script attempted to load `/directory` and produced a screenshot artifact, but the page returned a 500 (root cause: `DATABASE_URL` missing). 
- No automated unit/integration test suite was run; TypeScript/next build steps were exercised implicitly during `next dev` but full verification requires a configured `DATABASE_URL`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985e5d7f0d88331bd8df5ce97898f28)